### PR TITLE
async support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] Q3 2023
+ - replaced EventHandler by async API's
+ - switched to azure-iot-sdk-c convenient layer which brings its own thread safe runtime
+ - bumped to azure-iot-sdk-sys 0.6.0 which supports azure-iot-sdk-c convenient layer
+ - bumped to eis-utils 0.3.0 providing async 'request_connection_string_from_eis_with_expiry'
+
 ## [0.9.5] Q2 2023
  - removed get_ prefix from getters in order to be conform with rust convention
  - changed omnect git dependencies from ssh to https url's

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,5 @@ default = []
 device_client = ["eis-utils"]
 module_client = ["eis-utils"]
 edge_client = ["azure-iot-sdk-sys/edge_modules"]
-trace_sdk_c = []
+# enable logging in azure_sdk_for_c
+iot_c_sdk_logs = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure-iot-sdk"
-version = "0.9.5"
+version = "0.10.0"
 edition = "2021"
 authors = ["omnect@conplement.de>"]
 repository = "git@github.com:omnect/azure-iot-sdk.git"
@@ -9,11 +9,16 @@ repository = "git@github.com:omnect/azure-iot-sdk.git"
 
 [dependencies]
 anyhow = "1.0"
-azure-iot-sdk-sys = { git = "https://github.com/omnect/azure-iot-sdk-sys.git", tag = "0.5.8", default-features = false }
-eis-utils = { git = "https://github.com/omnect/eis-utils.git", tag = "0.2.6", optional = true }
+async-trait = "0.1"
+azure-iot-sdk-sys = { git = "https://github.com/omnect/azure-iot-sdk-sys.git", tag = "0.6.0", default-features = false }
+#eis-utils = { git = "https://github.com/omnect/eis-utils.git", tag = "0.3.0", optional = true }
+eis-utils = { git = "https://github.com/janzachmann/eis-utils.git", branch = "async_api", optional = true }
 log = "0.4"
 serde_json = "1.0"
-rand = "0.8"
+tokio = { version = "1", features = ["sync"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 [features]
 # select either "module_client", "edge_client" or "device_client" functionality
@@ -21,3 +26,4 @@ default = []
 device_client = ["eis-utils"]
 module_client = ["eis-utils"]
 edge_client = ["azure-iot-sdk-sys/edge_modules"]
+trace_sdk_c = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,7 @@ repository = "git@github.com:omnect/azure-iot-sdk.git"
 anyhow = "1.0"
 async-trait = "0.1"
 azure-iot-sdk-sys = { git = "https://github.com/omnect/azure-iot-sdk-sys.git", tag = "0.6.0", default-features = false }
-#eis-utils = { git = "https://github.com/omnect/eis-utils.git", tag = "0.3.0", optional = true }
-eis-utils = { git = "https://github.com/janzachmann/eis-utils.git", branch = "async_api", optional = true }
+eis-utils = { git = "https://github.com/omnect/eis-utils.git", tag = "0.3.0", optional = true }
 log = "0.4"
 serde_json = "1.0"
 tokio = { version = "1", features = ["sync"] }

--- a/src/client/message.rs
+++ b/src/client/message.rs
@@ -34,11 +34,11 @@ pub enum Direction {
 /// Let's you either create an outgoing D2C messages or parse an incoming cloud to device (C2D) messages.
 /// ```rust, no_run
 /// use azure_iot_sdk::client::*;
-/// 
+///
 /// #[tokio::main]
 /// async fn main() {
 ///     let mut client = IotHubClient::from_identity_service(None, None, None, None).await.unwrap();
-/// 
+///
 ///     let msg = IotMessage::builder()
 ///         .set_body(
 ///             serde_json::to_vec(r#"{"my telemetry message": "hi from device"}"#).unwrap(),
@@ -203,7 +203,7 @@ impl IotMessage {
             self.handle = Some(handle);
         }
 
-        Ok(self.handle.unwrap())
+        Ok(self.handle.expect("no handle"))
     }
 
     fn destroy_handle(&mut self) {
@@ -220,11 +220,11 @@ impl IotMessage {
 /// Builder for constructing outgoing D2C message instances
 /// ```rust, no_run
 /// use azure_iot_sdk::client::*;
-/// 
+///
 /// #[tokio::main]
 /// async fn main() {
 ///     let mut client = IotHubClient::from_identity_service(None, None, None, None).await.unwrap();
-/// 
+///
 ///     let msg = IotMessage::builder()
 ///         .set_body(
 ///             serde_json::to_vec(r#"{"my telemetry message": "hi from device"}"#).unwrap(),
@@ -254,11 +254,11 @@ impl IotMessageBuilder {
     /// Set the message body
     /// ```rust, no_run
     /// use azure_iot_sdk::client::*;
-    /// 
+    ///
     /// #[tokio::main]
     /// async fn main() {
     ///     let mut client = IotHubClient::from_identity_service(None, None, None, None).await.unwrap();
-    /// 
+    ///
     ///     let msg = IotMessage::builder()
     ///         .set_body(
     ///             serde_json::to_vec(r#"{"my telemetry message": "hi from device"}"#).unwrap(),
@@ -277,11 +277,11 @@ impl IotMessageBuilder {
     /// Set the identifier for this message
     /// ```rust, no_run
     /// use azure_iot_sdk::client::*;
-    /// 
+    ///
     /// #[tokio::main]
     /// async fn main() {
     ///     let mut client = IotHubClient::from_identity_service(None, None, None, None).await.unwrap();
-    /// 
+    ///
     ///     let msg = IotMessage::builder()
     ///         .set_id("my msg id")
     ///         .build()
@@ -301,7 +301,7 @@ impl IotMessageBuilder {
     /// #[tokio::main]
     /// async fn main() {
     ///     let mut client = IotHubClient::from_identity_service(None, None, None, None).await.unwrap();
-    /// 
+    ///
     ///     let msg = IotMessage::builder()
     ///         .set_correlation_id("my correlation id")
     ///         .build()
@@ -318,11 +318,11 @@ impl IotMessageBuilder {
     /// To allow routing query on the message body, this value should be set to `application/json`
     /// ```rust, no_run
     /// use azure_iot_sdk::client::*;
-    /// 
+    ///
     /// #[tokio::main]
     /// async fn main() {
     ///     let mut client = IotHubClient::from_identity_service(None, None, None, None).await.unwrap();
-    /// 
+    ///
     ///     let msg = IotMessage::builder()
     ///         .set_content_type("application/json")
     ///         .build()
@@ -340,11 +340,11 @@ impl IotMessageBuilder {
     /// To allow routing query on the message body, this value should be set to `application/json`
     /// ```rust, no_run
     /// use azure_iot_sdk::client::*;
-    /// 
+    ///
     /// #[tokio::main]
     /// async fn main() {
     ///     let mut client = IotHubClient::from_identity_service(None, None, None, None).await.unwrap();
-    /// 
+    ///
     ///     let msg = IotMessage::builder()
     ///         .set_content_encoding("UTF-8")
     ///         .build()
@@ -360,11 +360,11 @@ impl IotMessageBuilder {
     /// Set the output queue to be used with this message
     /// ```rust, no_run
     /// use azure_iot_sdk::client::*;
-    /// 
+    ///
     /// #[tokio::main]
     /// async fn main() {
     ///     let mut client = IotHubClient::from_identity_service(None, None, None, None).await.unwrap();
-    /// 
+    ///
     ///     let msg = IotMessage::builder()
     ///         .set_output_queue("my output queue")
     ///         .build()
@@ -381,11 +381,11 @@ impl IotMessageBuilder {
     /// Add a message property
     /// ```rust, no_run
     /// use azure_iot_sdk::client::*;
-    /// 
+    ///
     /// #[tokio::main]
     /// async fn main() {
     ///     let mut client = IotHubClient::from_identity_service(None, None, None, None).await.unwrap();
-    /// 
+    ///
     ///     let msg = IotMessage::builder()
     ///         .set_property("my key1", "my property1")
     ///         .set_property("my key2", "my property2")
@@ -404,7 +404,7 @@ impl IotMessageBuilder {
     pub fn build(self) -> Result<IotMessage> {
         Ok(IotMessage {
             handle: None,
-            body: self.message.unwrap(),
+            body: self.message.expect("no message buffer"),
             direction: Direction::Outgoing,
             output_queue: CString::new(self.output_queue)?,
             properties: self

--- a/src/client/message.rs
+++ b/src/client/message.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 /// incoming message result sent back to cloud
-/// https://azure.github.io/azure-iot-sdk-c/iothub__client__core__common_8h.html#a96cfa82412891d077ec835922ed5b626
+/// <https://azure.github.io/azure-iot-sdk-c/iothub__client__core__common_8h.html#a96cfa82412891d077ec835922ed5b626>
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum DispositionResult {
     /// accept incoming message

--- a/src/client/message.rs
+++ b/src/client/message.rs
@@ -1,10 +1,25 @@
 use anyhow::Result;
 use azure_iot_sdk_sys::*;
 use log::{error, info};
-use std::collections::HashMap;
-use std::ffi::CStr;
-use std::ffi::{CString, NulError};
-use std::slice;
+use std::{
+    collections::HashMap,
+    ffi::{CStr, CString, NulError},
+    slice,
+};
+
+/// incoming message result sent back to cloud
+/// https://azure.github.io/azure-iot-sdk-c/iothub__client__core__common_8h.html#a96cfa82412891d077ec835922ed5b626
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum DispositionResult {
+    /// accept incoming message
+    Accepted,
+    /// reject incoming message
+    Rejected,
+    /// abandon incoming message
+    Abandoned,
+    /// async ack incoming message
+    AsyncAck,
+}
 
 /// message direction
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
@@ -18,28 +33,28 @@ pub enum Direction {
 
 /// Let's you either create an outgoing D2C messages or parse an incoming cloud to device (C2D) messages.
 /// ```rust, no_run
-/// # use azure_iot_sdk::client::*;
-/// # struct MyEventHandler {}
-/// # impl EventHandler for MyEventHandler {}
-/// #
-/// # let event_handler = MyEventHandler{};
-/// # let mut client = IotHubClient::from_identity_service(event_handler).unwrap();
-/// #
-/// let msg = IotMessage::builder()
-///     .set_body(
-///         serde_json::to_vec(r#"{"my telemetry message": "hi from device"}"#).unwrap(),
-///     )
-///     .set_id("my msg id")
-///     .set_correlation_id("my correleation id")
-///     .set_property(
-///         "my property key",
-///         "my property value",
-///     )
-///     .set_output_queue("my output queue")
-///     .build()
-///     .unwrap();
+/// use azure_iot_sdk::client::*;
+/// 
+/// #[tokio::main]
+/// async fn main() {
+///     let mut client = IotHubClient::from_identity_service(None, None, None, None).await.unwrap();
+/// 
+///     let msg = IotMessage::builder()
+///         .set_body(
+///             serde_json::to_vec(r#"{"my telemetry message": "hi from device"}"#).unwrap(),
+///         )
+///         .set_id("my msg id")
+///         .set_correlation_id("my correleation id")
+///         .set_property(
+///             "my property key",
+///             "my property value",
+///         )
+///         .set_output_queue("my output queue")
+///         .build()
+///         .unwrap();
 ///
-/// client.send_d2c_message(msg);
+///     client.send_d2c_message(msg);
+/// }
 /// ```
 #[derive(Default, Debug, PartialEq)]
 pub struct IotMessage {
@@ -204,28 +219,28 @@ impl IotMessage {
 
 /// Builder for constructing outgoing D2C message instances
 /// ```rust, no_run
-/// # use azure_iot_sdk::client::*;
-/// # struct MyEventHandler {}
-/// # impl EventHandler for MyEventHandler {}
-/// #
-/// # let event_handler = MyEventHandler{};
-/// # let mut client = IotHubClient::from_identity_service(event_handler).unwrap();
-/// #
-/// let msg = IotMessage::builder()
-///     .set_body(
-///         serde_json::to_vec(r#"{"my telemetry message": "hi from device"}"#).unwrap(),
-///     )
-///     .set_id("my msg id")
-///     .set_correlation_id("my correleation id")
-///     .set_property(
-///         "my property key",
-///         "my property value",
-///     )
-///     .set_output_queue("my output queue")
-///     .build()
-///     .unwrap();
+/// use azure_iot_sdk::client::*;
+/// 
+/// #[tokio::main]
+/// async fn main() {
+///     let mut client = IotHubClient::from_identity_service(None, None, None, None).await.unwrap();
+/// 
+///     let msg = IotMessage::builder()
+///         .set_body(
+///             serde_json::to_vec(r#"{"my telemetry message": "hi from device"}"#).unwrap(),
+///         )
+///         .set_id("my msg id")
+///         .set_correlation_id("my correleation id")
+///         .set_property(
+///             "my property key",
+///             "my property value",
+///         )
+///         .set_output_queue("my output queue")
+///         .build()
+///         .unwrap();
 ///
-/// client.send_d2c_message(msg);
+///     client.send_d2c_message(msg);
+/// }
 /// ```
 #[derive(Debug, Default)]
 pub struct IotMessageBuilder {
@@ -238,21 +253,21 @@ pub struct IotMessageBuilder {
 impl IotMessageBuilder {
     /// Set the message body
     /// ```rust, no_run
-    /// # use azure_iot_sdk::client::*;
-    /// # struct MyEventHandler {}
-    /// # impl EventHandler for MyEventHandler {}
-    /// #
-    /// # let event_handler = MyEventHandler{};
-    /// # let mut client = IotHubClient::from_identity_service(event_handler).unwrap();
-    /// #
-    /// let msg = IotMessage::builder()
-    ///     .set_body(
-    ///         serde_json::to_vec(r#"{"my telemetry message": "hi from device"}"#).unwrap(),
-    ///     )
-    ///     .build()
-    ///     .unwrap();
+    /// use azure_iot_sdk::client::*;
+    /// 
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let mut client = IotHubClient::from_identity_service(None, None, None, None).await.unwrap();
+    /// 
+    ///     let msg = IotMessage::builder()
+    ///         .set_body(
+    ///             serde_json::to_vec(r#"{"my telemetry message": "hi from device"}"#).unwrap(),
+    ///         )
+    ///         .build()
+    ///         .unwrap();
     ///
-    /// client.send_d2c_message(msg);
+    ///     client.send_d2c_message(msg);
+    /// }
     /// ```
     pub fn set_body(mut self, body: Vec<u8>) -> Self {
         self.message = Some(body);
@@ -261,19 +276,19 @@ impl IotMessageBuilder {
 
     /// Set the identifier for this message
     /// ```rust, no_run
-    /// # use azure_iot_sdk::client::*;
-    /// # struct MyEventHandler {}
-    /// # impl EventHandler for MyEventHandler {}
-    /// #
-    /// # let event_handler = MyEventHandler{};
-    /// # let mut client = IotHubClient::from_identity_service(event_handler).unwrap();
-    /// #
-    /// let msg = IotMessage::builder()
-    ///     .set_id("my msg id")
-    ///     .build()
-    ///     .unwrap();
+    /// use azure_iot_sdk::client::*;
+    /// 
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let mut client = IotHubClient::from_identity_service(None, None, None, None).await.unwrap();
+    /// 
+    ///     let msg = IotMessage::builder()
+    ///         .set_id("my msg id")
+    ///         .build()
+    ///         .unwrap();
     ///
-    /// client.send_d2c_message(msg);
+    ///     client.send_d2c_message(msg);
+    /// }
     /// ```
     pub fn set_id(self, mid: impl Into<String>) -> Self {
         self.set_system_property("$.mid", mid)
@@ -281,19 +296,19 @@ impl IotMessageBuilder {
 
     /// Set the identifier for this message
     /// ```rust, no_run
-    /// # use azure_iot_sdk::client::*;
-    /// # struct MyEventHandler {}
-    /// # impl EventHandler for MyEventHandler {}
+    /// use azure_iot_sdk::client::*;
     ///
-    /// # let event_handler = MyEventHandler{};
-    /// # let mut client = IotHubClient::from_identity_service(event_handler).unwrap();
-    /// #
-    /// let msg = IotMessage::builder()
-    ///     .set_correlation_id("my correlation id")
-    ///     .build()
-    ///     .unwrap();
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let mut client = IotHubClient::from_identity_service(None, None, None, None).await.unwrap();
+    /// 
+    ///     let msg = IotMessage::builder()
+    ///         .set_correlation_id("my correlation id")
+    ///         .build()
+    ///         .unwrap();
     ///
-    /// client.send_d2c_message(msg);
+    ///     client.send_d2c_message(msg);
+    /// }
     /// ```
     pub fn set_correlation_id(self, cid: impl Into<String>) -> Self {
         self.set_system_property("$.cid", cid)
@@ -302,19 +317,19 @@ impl IotMessageBuilder {
     /// Set the content-type for this message, such as `text/plain`.
     /// To allow routing query on the message body, this value should be set to `application/json`
     /// ```rust, no_run
-    /// # use azure_iot_sdk::client::*;
-    /// # struct MyEventHandler {}
-    /// # impl EventHandler for MyEventHandler {}
-    /// #
-    /// # let event_handler = MyEventHandler{};
-    /// # let mut client = IotHubClient::from_identity_service(event_handler).unwrap();
-    /// #
-    /// let msg = IotMessage::builder()
-    ///     .set_content_type("application/json")
-    ///     .build()
-    ///     .unwrap();
+    /// use azure_iot_sdk::client::*;
+    /// 
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let mut client = IotHubClient::from_identity_service(None, None, None, None).await.unwrap();
+    /// 
+    ///     let msg = IotMessage::builder()
+    ///         .set_content_type("application/json")
+    ///         .build()
+    ///         .unwrap();
     ///
-    /// client.send_d2c_message(msg);
+    ///     client.send_d2c_message(msg);
+    /// }
     /// ```
     pub fn set_content_type(self, content_type: impl Into<String>) -> Self {
         self.set_system_property("$.ct", content_type)
@@ -324,19 +339,19 @@ impl IotMessageBuilder {
     /// If the content-type is set to `application/json`, allowed values are `UTF-8`, `UTF-16`, `UTF-32`
     /// To allow routing query on the message body, this value should be set to `application/json`
     /// ```rust, no_run
-    /// # use azure_iot_sdk::client::*;
-    /// # struct MyEventHandler {}
-    /// # impl EventHandler for MyEventHandler {}
-    /// #
-    /// # let event_handler = MyEventHandler{};
-    /// # let mut client = IotHubClient::from_identity_service(event_handler).unwrap();
-    /// #
-    /// let msg = IotMessage::builder()
-    ///     .set_content_encoding("UTF-8")
-    ///     .build()
-    ///     .unwrap();
+    /// use azure_iot_sdk::client::*;
+    /// 
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let mut client = IotHubClient::from_identity_service(None, None, None, None).await.unwrap();
+    /// 
+    ///     let msg = IotMessage::builder()
+    ///         .set_content_encoding("UTF-8")
+    ///         .build()
+    ///         .unwrap();
     ///
-    /// client.send_d2c_message(msg);
+    ///     client.send_d2c_message(msg);
+    /// }
     /// ```
     pub fn set_content_encoding(self, content_encoding: impl Into<String>) -> Self {
         self.set_system_property("$.ce", content_encoding)
@@ -344,19 +359,19 @@ impl IotMessageBuilder {
 
     /// Set the output queue to be used with this message
     /// ```rust, no_run
-    /// # use azure_iot_sdk::client::*;
-    /// # struct MyEventHandler {}
-    /// # impl EventHandler for MyEventHandler {}
-    /// #
-    /// # let event_handler = MyEventHandler{};
-    /// # let mut client = IotHubClient::from_identity_service(event_handler).unwrap();
-    /// #
-    /// let msg = IotMessage::builder()
-    ///     .set_output_queue("my output queue")
-    ///     .build()
-    ///     .unwrap();
+    /// use azure_iot_sdk::client::*;
+    /// 
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let mut client = IotHubClient::from_identity_service(None, None, None, None).await.unwrap();
+    /// 
+    ///     let msg = IotMessage::builder()
+    ///         .set_output_queue("my output queue")
+    ///         .build()
+    ///         .unwrap();
     ///
-    /// client.send_d2c_message(msg);
+    ///     client.send_d2c_message(msg);
+    /// }
     /// ```
     pub fn set_output_queue(mut self, queue: impl Into<String>) -> Self {
         self.output_queue = queue.into();
@@ -365,20 +380,20 @@ impl IotMessageBuilder {
 
     /// Add a message property
     /// ```rust, no_run
-    /// # use azure_iot_sdk::client::*;
-    /// # struct MyEventHandler {}
-    /// # impl EventHandler for MyEventHandler {}
-    /// #
-    /// # let event_handler = MyEventHandler{};
-    /// # let mut client = IotHubClient::from_identity_service(event_handler).unwrap();
-    /// #
-    /// let msg = IotMessage::builder()
-    ///     .set_property("my key1", "my property1")
-    ///     .set_property("my key2", "my property2")
-    ///     .build()
-    ///     .unwrap();
+    /// use azure_iot_sdk::client::*;
+    /// 
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let mut client = IotHubClient::from_identity_service(None, None, None, None).await.unwrap();
+    /// 
+    ///     let msg = IotMessage::builder()
+    ///         .set_property("my key1", "my property1")
+    ///         .set_property("my key2", "my property2")
+    ///         .build()
+    ///         .unwrap();
     ///
-    /// client.send_d2c_message(msg);
+    ///     client.send_d2c_message(msg);
+    /// }
     /// ```
     pub fn set_property(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         self.properties.insert(key.into(), value.into());

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -485,7 +485,7 @@ impl IotHubClient {
     }
 
     fn set_options(&mut self) -> Result<()> {
-        if cfg!(feature = "trace_sdk_c") {
+        if cfg!(feature = "iot_c_sdk_logs") {
             self.twin.set_option(
                 CString::new("logtrace")?,
                 &mut true as *mut bool as *mut c_void,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,4 +1,4 @@
-//! Let's you create an instance of [`Self::IotHubClient`] with integrated [`Self::IotHubCallbacks`].
+//! Let's you create an instance of [`Self::IotHubClient`].
 
 #[cfg(not(any(
     feature = "device_client",
@@ -41,11 +41,6 @@ use std::{
 use tokio::sync::{
     Notify, {mpsc, oneshot},
 };
-
-/*
-check unwraps
-check send without network/confirmation
-*/
 
 /// used by iothub client consumer to send the result of a direct method
 pub type DirectMethodResult = oneshot::Sender<Result<Option<serde_json::Value>>>;

--- a/src/client/twin.rs
+++ b/src/client/twin.rs
@@ -91,11 +91,7 @@ pub trait Twin {
         ctx: *mut std::ffi::c_void,
     ) -> Result<()>;
 
-    fn set_option(
-        &self,
-        option_name: CString,
-        value: *mut std::ffi::c_void,
-    ) -> Result<()>;
+    fn set_option(&self, option_name: CString, value: *mut std::ffi::c_void) -> Result<()>;
 }
 
 #[cfg(feature = "edge_client")]
@@ -138,7 +134,7 @@ impl Twin for ModuleTwin {
 
     fn destroy(&mut self) {
         unsafe {
-            IoTHubModuleClient_Destroy(self.handle.unwrap());
+            IoTHubModuleClient_Destroy(self.handle.expect("no handle"));
         }
     }
 
@@ -152,7 +148,7 @@ impl Twin for ModuleTwin {
         unsafe {
             if IOTHUB_CLIENT_RESULT_TAG_IOTHUB_CLIENT_OK
                 != IoTHubModuleClient_SendEventToOutputAsync(
-                    self.handle.unwrap(),
+                    self.handle.expect("no handle"),
                     message_handle,
                     queue.as_ptr(),
                     callback,
@@ -176,7 +172,7 @@ impl Twin for ModuleTwin {
         unsafe {
             if IOTHUB_CLIENT_RESULT_TAG_IOTHUB_CLIENT_OK
                 != IoTHubModuleClient_SendReportedState(
-                    self.handle.unwrap(),
+                    self.handle.expect("no handle"),
                     reported_state.into_raw() as *mut u8,
                     size,
                     callback,
@@ -198,7 +194,7 @@ impl Twin for ModuleTwin {
         unsafe {
             if IOTHUB_CLIENT_RESULT_TAG_IOTHUB_CLIENT_OK
                 != IoTHubModuleClient_SetConnectionStatusCallback(
-                    self.handle.unwrap(),
+                    self.handle.expect("no handle"),
                     callback,
                     ctx,
                 )
@@ -221,7 +217,7 @@ impl Twin for ModuleTwin {
             let input_name = CString::new("input")?;
             if IOTHUB_CLIENT_RESULT_TAG_IOTHUB_CLIENT_OK
                 != IoTHubModuleClient_SetInputMessageCallback(
-                    self.handle.unwrap(),
+                    self.handle.expect("no handle"),
                     input_name.as_ptr(),
                     callback,
                     ctx,
@@ -241,7 +237,11 @@ impl Twin for ModuleTwin {
     ) -> Result<()> {
         unsafe {
             if IOTHUB_CLIENT_RESULT_TAG_IOTHUB_CLIENT_OK
-                != IoTHubModuleClient_SetModuleTwinCallback(self.handle.unwrap(), callback, ctx)
+                != IoTHubModuleClient_SetModuleTwinCallback(
+                    self.handle.expect("no handle"),
+                    callback,
+                    ctx,
+                )
             {
                 anyhow::bail!("error while calling IoTHubModuleClient_SetModuleTwinCallback()",);
             }
@@ -257,7 +257,7 @@ impl Twin for ModuleTwin {
     ) -> Result<()> {
         unsafe {
             if IOTHUB_CLIENT_RESULT_TAG_IOTHUB_CLIENT_OK
-                != IoTHubModuleClient_GetTwinAsync(self.handle.unwrap(), callback, ctx)
+                != IoTHubModuleClient_GetTwinAsync(self.handle.expect("no handle"), callback, ctx)
             {
                 anyhow::bail!("error while calling IoTHubModuleClient_GetTwinAsync()",);
             }
@@ -273,7 +273,11 @@ impl Twin for ModuleTwin {
     ) -> Result<()> {
         unsafe {
             if IOTHUB_CLIENT_RESULT_TAG_IOTHUB_CLIENT_OK
-                != IoTHubModuleClient_SetModuleMethodCallback(self.handle.unwrap(), callback, ctx)
+                != IoTHubModuleClient_SetModuleMethodCallback(
+                    self.handle.expect("no handle"),
+                    callback,
+                    ctx,
+                )
             {
                 anyhow::bail!("error while calling IoTHubModuleClient_SetModuleMethodCallback()",);
             }
@@ -282,14 +286,14 @@ impl Twin for ModuleTwin {
         }
     }
 
-    fn set_option(
-        &self,
-        option_name: CString,
-        value: *mut std::ffi::c_void,
-    ) -> Result<()>{
+    fn set_option(&self, option_name: CString, value: *mut std::ffi::c_void) -> Result<()> {
         unsafe {
             if IOTHUB_CLIENT_RESULT_TAG_IOTHUB_CLIENT_OK
-                != IoTHubModuleClient_SetOption(self.handle.unwrap(), option_name.into_raw(), value)
+                != IoTHubModuleClient_SetOption(
+                    self.handle.expect("no handle"),
+                    option_name.into_raw(),
+                    value,
+                )
             {
                 anyhow::bail!("error while calling IoTHubModuleClient_SetOption()",);
             }
@@ -322,7 +326,7 @@ impl Twin for DeviceTwin {
 
     fn destroy(&mut self) {
         unsafe {
-            IoTHubDeviceClient_Destroy(self.handle.unwrap());
+            IoTHubDeviceClient_Destroy(self.handle.expect("no handle"));
         }
     }
 
@@ -335,7 +339,7 @@ impl Twin for DeviceTwin {
     ) -> Result<()> {
         unsafe {
             let result = IoTHubDeviceClient_SendEventAsync(
-                self.handle.unwrap(),
+                self.handle.expect("no handle"),
                 message_handle,
                 callback,
                 ctx as *mut c_void,
@@ -359,7 +363,7 @@ impl Twin for DeviceTwin {
         unsafe {
             if IOTHUB_CLIENT_RESULT_TAG_IOTHUB_CLIENT_OK
                 != IoTHubDeviceClient_SendReportedState(
-                    self.handle.unwrap(),
+                    self.handle.expect("no handle"),
                     reported_state.into_raw() as *mut u8,
                     size,
                     callback,
@@ -381,7 +385,7 @@ impl Twin for DeviceTwin {
         unsafe {
             if IOTHUB_CLIENT_RESULT_TAG_IOTHUB_CLIENT_OK
                 != IoTHubDeviceClient_SetConnectionStatusCallback(
-                    self.handle.unwrap(),
+                    self.handle.expect("no handle"),
                     callback,
                     ctx,
                 )
@@ -402,7 +406,11 @@ impl Twin for DeviceTwin {
     ) -> Result<()> {
         unsafe {
             if IOTHUB_CLIENT_RESULT_TAG_IOTHUB_CLIENT_OK
-                != IoTHubDeviceClient_SetMessageCallback(self.handle.unwrap(), callback, ctx)
+                != IoTHubDeviceClient_SetMessageCallback(
+                    self.handle.expect("no handle"),
+                    callback,
+                    ctx,
+                )
             {
                 anyhow::bail!("error while calling IoTHubDeviceClient_SetMessageCallback()",);
             }
@@ -418,7 +426,11 @@ impl Twin for DeviceTwin {
     ) -> Result<()> {
         unsafe {
             if IOTHUB_CLIENT_RESULT_TAG_IOTHUB_CLIENT_OK
-                != IoTHubDeviceClient_SetDeviceTwinCallback(self.handle.unwrap(), callback, ctx)
+                != IoTHubDeviceClient_SetDeviceTwinCallback(
+                    self.handle.expect("no handle"),
+                    callback,
+                    ctx,
+                )
             {
                 anyhow::bail!("error while calling IoTHubDeviceClient_SetDeviceTwinCallback()",);
             }
@@ -434,7 +446,7 @@ impl Twin for DeviceTwin {
     ) -> Result<()> {
         unsafe {
             if IOTHUB_CLIENT_RESULT_TAG_IOTHUB_CLIENT_OK
-                != IoTHubDeviceClient_GetTwinAsync(self.handle.unwrap(), callback, ctx)
+                != IoTHubDeviceClient_GetTwinAsync(self.handle.expect("no handle"), callback, ctx)
             {
                 anyhow::bail!("error while calling IoTHubDeviceClient_GetTwinAsync()",);
             }
@@ -450,7 +462,11 @@ impl Twin for DeviceTwin {
     ) -> Result<()> {
         unsafe {
             if IOTHUB_CLIENT_RESULT_TAG_IOTHUB_CLIENT_OK
-                != IoTHubDeviceClient_SetDeviceMethodCallback(self.handle.unwrap(), callback, ctx)
+                != IoTHubDeviceClient_SetDeviceMethodCallback(
+                    self.handle.expect("no handle"),
+                    callback,
+                    ctx,
+                )
             {
                 anyhow::bail!("error while calling IoTHubDeviceClient_SetDeviceMethodCallback()",);
             }
@@ -459,14 +475,14 @@ impl Twin for DeviceTwin {
         }
     }
 
-    fn set_option(
-        &self,
-        option_name: CString,
-        value: *mut std::ffi::c_void,
-    ) -> Result<()>{
+    fn set_option(&self, option_name: CString, value: *mut std::ffi::c_void) -> Result<()> {
         unsafe {
             if IOTHUB_CLIENT_RESULT_TAG_IOTHUB_CLIENT_OK
-                != IoTHubDeviceClient_SetOption(self.handle.unwrap(), option_name.into_raw(), value)
+                != IoTHubDeviceClient_SetOption(
+                    self.handle.expect("no handle"),
+                    option_name.into_raw(),
+                    value,
+                )
             {
                 anyhow::bail!("error while calling IoTHubDeviceClient_SetOption()",);
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![warn(missing_docs)]
-
 //! Wrapper around azure iot-c-sdk-ref.
 //!
 //! A reference implementation can be found [here](https://github.com/omnect/iot-client-template-rs).
@@ -28,5 +27,5 @@
 //! - [device to cloud (D2C) messages](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-d2c)
 //! - [cloud to device (C2D) messages](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-c2d)
 
-/// iothub client
+/// A module providing code to establish a connection to iothub.
 pub mod client;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 
 //! Wrapper around azure iot-c-sdk-ref.
 //!
-//! A reference implementation can be found [here](https://github.com/omnect/iot-client-template-rs).//!
+//! A reference implementation can be found [here](https://github.com/omnect/iot-client-template-rs).
 //!
 //! Provides an abstraction over Microsoft's iot-c-sdk in order to develop device- and module twin client applications.
 //! All API's exposed by this crate base on the following low level function interfaces:


### PR DESCRIPTION
- replaced EventHandler by async API's
- switched to azure-iot-sdk-c convenient layer which brings its own thread safe runtime
- bumped to azure-iot-sdk-sys 0.6.0 which supports azure-iot-sdk-c convenient layer
- bumped to eis-utils 0.3.0 providing async 'request_connection_string_from_eis_with_expiry'