### PR TITLE
 - fixed potential deadlocks when e.g. direct_method and reported pro…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] Q3 2023
+ - fixed potential deadlocks when e.g. direct_method and reported property confirmation
+   callbacks share the same thread at the same time in azure-c-sdk
+ - a JoinSet now holds tasks that are waiting for confirmation with a timeout
+
 ## [0.10.1] Q3 2023
  - fixed inaccuracies in IoTMessage docstrings
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure-iot-sdk"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 authors = ["omnect@conplement.de>"]
 repository = "git@github.com:omnect/azure-iot-sdk.git"
@@ -12,9 +12,10 @@ anyhow = "1.0"
 async-trait = "0.1"
 azure-iot-sdk-sys = { git = "https://github.com/omnect/azure-iot-sdk-sys.git", tag = "0.6.0", default-features = false }
 eis-utils = { git = "https://github.com/omnect/eis-utils.git", tag = "0.3.0", optional = true }
+futures = "0.3"
 log = "0.4"
 serde_json = "1.0"
-tokio = { version = "1", features = ["sync"] }
+tokio = { version = "1", features = ["rt", "sync", "time"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -858,7 +858,7 @@ impl IotHubClient {
         status_code: std::os::raw::c_int,
         context: *mut ::std::os::raw::c_void,
     ) {
-        debug!("SendReportedTwin result: {status_code}");
+        trace!("SendReportedTwin result: {status_code}");
 
         let result: Box<oneshot::Sender<bool>> =
             Box::from_raw(context as *mut oneshot::Sender<bool>);
@@ -990,7 +990,7 @@ impl IotHubClient {
             poll = self.confirmation_set.poll_join_next(&mut cx);
         }
 
-        debug!(
+        trace!(
             "cleaned {} confirmations",
             before - self.confirmation_set.len()
         );

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -29,7 +29,7 @@ use core::slice;
 #[cfg(any(feature = "module_client", feature = "device_client"))]
 use eis_utils::*;
 use futures::task;
-use log::{debug, error};
+use log::{debug, error, trace};
 use serde_json::json;
 use std::{
     boxed::Box,
@@ -995,7 +995,7 @@ impl IotHubClient {
             before - self.confirmation_set.len()
         );
 
-        // spawn a task to handle the folowwing results:
+        // spawn a task to handle the following results:
         //   - succeeded
         //   - failed
         //   - timed out
@@ -1003,7 +1003,7 @@ impl IotHubClient {
             match timeout(Duration::from_secs(Self::CONFIRMATION_TIMEOUT_SECS), rx).await {
                 Ok(Ok(false)) => panic!("twin_report: failed"),
                 Err(_) => panic!("twin_report: timed out"),
-                _ => debug!("twin_report: succeeded"),
+                _ => trace!("twin_report: succeeded"),
             }
         });
     }

--- a/src/client/twin.rs
+++ b/src/client/twin.rs
@@ -46,7 +46,7 @@ pub trait Twin {
     fn destroy(&mut self);
 
     fn send_event_to_output_async(
-        &mut self,
+        &self,
         message_handle: IOTHUB_MESSAGE_HANDLE,
         queue: CString,
         callback: IOTHUB_CLIENT_EVENT_CONFIRMATION_CALLBACK,
@@ -139,7 +139,7 @@ impl Twin for ModuleTwin {
     }
 
     fn send_event_to_output_async(
-        &mut self,
+        &self,
         message_handle: IOTHUB_MESSAGE_HANDLE,
         queue: CString,
         callback: IOTHUB_CLIENT_EVENT_CONFIRMATION_CALLBACK,
@@ -331,7 +331,7 @@ impl Twin for DeviceTwin {
     }
 
     fn send_event_to_output_async(
-        &mut self,
+        &self,
         message_handle: IOTHUB_MESSAGE_HANDLE,
         _queue: CString,
         callback: IOTHUB_CLIENT_EVENT_CONFIRMATION_CALLBACK,


### PR DESCRIPTION
…perty confirmation

   callbacks share the same thread at the same time in azure-c-sdk
 - a JoinSet now holds tasks that are waiting for confirmation with a timeout