### PR TITLE
message: add missing message property encoding skipped by c library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.1] Q3 2023
+ - fixed encoding for message properties.
+ - fixed lint warnings
+ - fixed code style
+
 ## [0.11.0] Q3 2023
  - fixed potential deadlocks when e.g. direct_method and reported property confirmation
    callbacks share the same thread at the same time in azure-c-sdk

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = "1.0"
 async-trait = "0.1"
 azure-iot-sdk-sys = { git = "https://github.com/omnect/azure-iot-sdk-sys.git", tag = "0.6.0", default-features = false }
 eis-utils = { git = "https://github.com/omnect/eis-utils.git", tag = "0.3.0", optional = true }
+form_urlencoded = "1.2.0"
 futures = "0.3"
 log = "0.4"
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure-iot-sdk"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 authors = ["omnect@conplement.de>"]
 repository = "git@github.com:omnect/azure-iot-sdk.git"

--- a/src/client/message.rs
+++ b/src/client/message.rs
@@ -396,7 +396,10 @@ impl IotMessageBuilder {
     /// }
     /// ```
     pub fn set_property(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
-        self.properties.insert(key.into(), value.into());
+        let key = IotMessageBuilder::urlencode(key);
+        let value = IotMessageBuilder::urlencode(value);
+
+        self.properties.insert(key, value);
         self
     }
 
@@ -439,8 +442,16 @@ impl IotMessageBuilder {
         property_name: impl Into<String>,
         value: impl Into<String>,
     ) -> Self {
-        self.system_properties
-            .insert(property_name.into(), value.into());
+        // we don't have to encode property_names as they are only used internally
+        let value = IotMessageBuilder::urlencode(value);
+
+        self.system_properties.insert(property_name.into(), value);
         self
+    }
+
+    fn urlencode(value: impl Into<String>) -> String {
+        form_urlencoded::Serializer::new(String::new())
+            .append_key_only(&value.into())
+            .finish()
     }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -31,6 +31,8 @@ use eis_utils::*;
 use futures::task;
 use log::{debug, error, trace};
 use serde_json::json;
+#[cfg(any(feature = "module_client", feature = "device_client"))]
+use std::time::SystemTime;
 use std::{
     boxed::Box,
     ffi::{c_void, CStr, CString},
@@ -38,8 +40,6 @@ use std::{
     sync::Once,
     task::{Context, Poll},
 };
-#[cfg(any(feature = "module_client", feature = "device_client"))]
-use std::time::SystemTime;
 use tokio::{
     sync::{mpsc, oneshot},
     task::{JoinError, JoinSet},

--- a/src/client/twin.rs
+++ b/src/client/twin.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use azure_iot_sdk_sys::*;
-use std::ffi::{c_void, CStr, CString};
+use std::ffi::{CStr, CString};
 
 #[cfg(any(feature = "module_client", feature = "edge_client"))]
 #[derive(Default, Debug)]
@@ -152,7 +152,7 @@ impl Twin for ModuleTwin {
                     message_handle,
                     queue.as_ptr(),
                     callback,
-                    ctx as *mut c_void,
+                    ctx as *mut std::ffi::c_void,
                 )
             {
                 anyhow::bail!("error while calling IoTHubModuleClient_SendEventToOutputAsync()",);
@@ -342,7 +342,7 @@ impl Twin for DeviceTwin {
                 self.handle.expect("no handle"),
                 message_handle,
                 callback,
-                ctx as *mut c_void,
+                ctx,
             );
 
             if result != IOTHUB_CLIENT_RESULT_TAG_IOTHUB_CLIENT_OK {


### PR DESCRIPTION
The Azure IoT Hub expects message properties to be url encoded. However, the C azure-iot-sdk does not perform such an encoding (see also https://github.com/Azure/azure-iot-sdk-python/issues/227 for a discussion of this issue). The effect of this is, that setting e.g. the message content type to "application/json" as suggested by the docstrings, leads to the IoT hub not accepting them.

This commit takes care to urlencode message property keys and values.