### PR TITLE
outgoing message confirmation timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.10] Q1 2024
+ - outgoing message confirmation timeout:
+   - increased from 5s to 10s
+   - made configurable by AZURE_SDK_CONFIRMATION_TIMEOUT_IN_SECS environment variable
+   - metioned in README.md
+
 ## [0.11.9] Q1 2024
  - set default do_work frequency to 100ms 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["omnect@conplement.de>"]
 edition = "2021"
 name = "azure-iot-sdk"
 repository = "git@github.com:omnect/azure-iot-sdk.git"
-version = "0.11.9"
+version = "0.11.10"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -14,6 +14,7 @@ azure-iot-sdk-sys = { git = "https://github.com/omnect/azure-iot-sdk-sys.git", t
 eis-utils = { git = "https://github.com/omnect/eis-utils.git", tag = "0.3.2", optional = true }
 futures = "0.3"
 log = "0.4"
+once_cell = "1.19"
 serde_json = "1.0"
 tokio = { version = "1", features = ["rt", "sync", "time"] }
 url = "2.4"

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ In order to create the purposed iot client, the crate must be configured via car
 
 The underlying azure-iot-sdk-c runs its main loop every 1ms by default. This timing can be changed in a range of 1...100ms by setting `AZURE_SDK_DO_WORK_FREQUENCY_IN_MS` environment variable.
 
+### Outgoing message confirmation timeout
+
+The sdk expects a valid confirmation after a reported property was updated or a device to cloud (D2C) message was sent. The sdk panics in case the confirmation cannot be received in time. The corresponding timeout can be configured by setting AZURE_SDK_CONFIRMATION_TIMEOUT_IN_SECS environment variable.
+
 ### Logging
 
 The underlying azure-iot-sdk-c logging can be enabled by creating `AZURE_SDK_LOGGING` environment variable with a whatsoever value.


### PR DESCRIPTION
   - increased from 5s to 10s
   - made configurable by AZURE_SDK_CONFIRMATION_TIMEOUT_IN_SECS environment variable
   - metioned in README.md