### PR TITLE
feat: introduced builder pattern in order to add new API's and optimize existing ones

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,10 @@ version = "0.12.0"
 
 [dependencies]
 anyhow = "1.0"
-async-trait = "0.1"
 azure-iot-sdk-sys = { git = "https://github.com/omnect/azure-iot-sdk-sys.git", tag = "0.6.0", default-features = false }
 eis-utils = { git = "https://github.com/omnect/eis-utils.git", tag = "0.3.2", optional = true }
 futures = "0.3"
 log = "0.4"
-once_cell = "1.19"
 serde_json = "1.0"
 tokio = { version = "1", features = ["rt", "sync", "time"] }
 url = "2.4"
@@ -25,6 +23,6 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 [features]
 # select either "module_client", "edge_client" or "device_client" functionality
 default = []
-device_client = ["eis-utils"]
+device_client = []
 module_client = ["eis-utils"]
 edge_client = ["azure-iot-sdk-sys/edge_modules"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["omnect@conplement.de>"]
 edition = "2021"
 name = "azure-iot-sdk"
 repository = "git@github.com:omnect/azure-iot-sdk.git"
-version = "0.11.10"
+version = "0.12.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/client/message.rs
+++ b/src/client/message.rs
@@ -37,7 +37,12 @@ pub enum Direction {
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     let mut client = IotHubClient::from_identity_service(None, None, None, None).await.unwrap();
+///     #[cfg(feature = "edge_client")]
+///     let mut client = IotHubClient::builder().build_edge_client().unwrap();
+///     #[cfg(feature = "device_client")]
+///     let mut client = IotHubClient::builder().build_device_client("my-connection-string").unwrap();
+///     #[cfg(feature = "module_client")]
+///     let mut client = IotHubClient::builder().build_module_client("my-connection-string").unwrap();
 ///
 ///     let msg = IotMessage::builder()
 ///         .set_body(
@@ -223,7 +228,12 @@ impl IotMessage {
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     let mut client = IotHubClient::from_identity_service(None, None, None, None).await.unwrap();
+///     #[cfg(feature = "edge_client")]
+///     let mut client = IotHubClient::builder().build_edge_client().unwrap();
+///     #[cfg(feature = "device_client")]
+///     let mut client = IotHubClient::builder().build_device_client("my-connection-string").unwrap();
+///     #[cfg(feature = "module_client")]
+///     let mut client = IotHubClient::builder().build_module_client("my-connection-string").unwrap();
 ///
 ///     let msg = IotMessage::builder()
 ///         .set_body(
@@ -257,7 +267,12 @@ impl IotMessageBuilder {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let mut client = IotHubClient::from_identity_service(None, None, None, None).await.unwrap();
+    ///     #[cfg(feature = "edge_client")]
+    ///     let mut client = IotHubClient::builder().build_edge_client().unwrap();
+    ///     #[cfg(feature = "device_client")]
+    ///     let mut client = IotHubClient::builder().build_device_client("my-connection-string").unwrap();
+    ///     #[cfg(feature = "module_client")]
+    ///     let mut client = IotHubClient::builder().build_module_client("my-connection-string").unwrap();
     ///
     ///     let msg = IotMessage::builder()
     ///         .set_body(
@@ -280,7 +295,12 @@ impl IotMessageBuilder {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let mut client = IotHubClient::from_identity_service(None, None, None, None).await.unwrap();
+    ///     #[cfg(feature = "edge_client")]
+    ///     let mut client = IotHubClient::builder().build_edge_client().unwrap();
+    ///     #[cfg(feature = "device_client")]
+    ///     let mut client = IotHubClient::builder().build_device_client("my-connection-string").unwrap();
+    ///     #[cfg(feature = "module_client")]
+    ///     let mut client = IotHubClient::builder().build_module_client("my-connection-string").unwrap();
     ///
     ///     let msg = IotMessage::builder()
     ///         .set_id("my msg id")
@@ -300,7 +320,12 @@ impl IotMessageBuilder {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let mut client = IotHubClient::from_identity_service(None, None, None, None).await.unwrap();
+    ///     #[cfg(feature = "edge_client")]
+    ///     let mut client = IotHubClient::builder().build_edge_client().unwrap();
+    ///     #[cfg(feature = "device_client")]
+    ///     let mut client = IotHubClient::builder().build_device_client("my-connection-string").unwrap();
+    ///     #[cfg(feature = "module_client")]
+    ///     let mut client = IotHubClient::builder().build_module_client("my-connection-string").unwrap();
     ///
     ///     let msg = IotMessage::builder()
     ///         .set_correlation_id("my correlation id")
@@ -321,7 +346,12 @@ impl IotMessageBuilder {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let mut client = IotHubClient::from_identity_service(None, None, None, None).await.unwrap();
+    ///     #[cfg(feature = "edge_client")]
+    ///     let mut client = IotHubClient::builder().build_edge_client().unwrap();
+    ///     #[cfg(feature = "device_client")]
+    ///     let mut client = IotHubClient::builder().build_device_client("my-connection-string").unwrap();
+    ///     #[cfg(feature = "module_client")]
+    ///     let mut client = IotHubClient::builder().build_module_client("my-connection-string").unwrap();
     ///
     ///     let msg = IotMessage::builder()
     ///         .set_content_type("application/json")
@@ -343,7 +373,12 @@ impl IotMessageBuilder {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let mut client = IotHubClient::from_identity_service(None, None, None, None).await.unwrap();
+    ///     #[cfg(feature = "edge_client")]
+    ///     let mut client = IotHubClient::builder().build_edge_client().unwrap();
+    ///     #[cfg(feature = "device_client")]
+    ///     let mut client = IotHubClient::builder().build_device_client("my-connection-string").unwrap();
+    ///     #[cfg(feature = "module_client")]
+    ///     let mut client = IotHubClient::builder().build_module_client("my-connection-string").unwrap();
     ///
     ///     let msg = IotMessage::builder()
     ///         .set_content_encoding("UTF-8")
@@ -363,7 +398,12 @@ impl IotMessageBuilder {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let mut client = IotHubClient::from_identity_service(None, None, None, None).await.unwrap();
+    ///     #[cfg(feature = "edge_client")]
+    ///     let mut client = IotHubClient::builder().build_edge_client().unwrap();
+    ///     #[cfg(feature = "device_client")]
+    ///     let mut client = IotHubClient::builder().build_device_client("my-connection-string").unwrap();
+    ///     #[cfg(feature = "module_client")]
+    ///     let mut client = IotHubClient::builder().build_module_client("my-connection-string").unwrap();
     ///
     ///     let msg = IotMessage::builder()
     ///         .set_output_queue("my output queue")
@@ -384,7 +424,12 @@ impl IotMessageBuilder {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let mut client = IotHubClient::from_identity_service(None, None, None, None).await.unwrap();
+    ///     #[cfg(feature = "edge_client")]
+    ///     let mut client = IotHubClient::builder().build_edge_client().unwrap();
+    ///     #[cfg(feature = "device_client")]
+    ///     let mut client = IotHubClient::builder().build_device_client("my-connection-string").unwrap();
+    ///     #[cfg(feature = "module_client")]
+    ///     let mut client = IotHubClient::builder().build_module_client("my-connection-string").unwrap();
     ///
     ///     let msg = IotMessage::builder()
     ///         .set_property("my key1", "my property1")

--- a/src/client/twin.rs
+++ b/src/client/twin.rs
@@ -91,7 +91,7 @@ pub trait Twin {
         ctx: *mut std::ffi::c_void,
     ) -> Result<()>;
 
-    fn set_option(&self, option_name: CString, value: *mut std::ffi::c_void) -> Result<()>;
+    fn set_option(&self, option_name: CString, value: *const std::ffi::c_void) -> Result<()>;
 }
 
 #[cfg(feature = "edge_client")]
@@ -286,7 +286,7 @@ impl Twin for ModuleTwin {
         }
     }
 
-    fn set_option(&self, option_name: CString, value: *mut std::ffi::c_void) -> Result<()> {
+    fn set_option(&self, option_name: CString, value: *const std::ffi::c_void) -> Result<()> {
         unsafe {
             if IOTHUB_CLIENT_RESULT_TAG_IOTHUB_CLIENT_OK
                 != IoTHubModuleClient_SetOption(
@@ -475,7 +475,7 @@ impl Twin for DeviceTwin {
         }
     }
 
-    fn set_option(&self, option_name: CString, value: *mut std::ffi::c_void) -> Result<()> {
+    fn set_option(&self, option_name: CString, value: *const std::ffi::c_void) -> Result<()> {
         unsafe {
             if IOTHUB_CLIENT_RESULT_TAG_IOTHUB_CLIENT_OK
                 != IoTHubDeviceClient_SetOption(

--- a/src/client/twin.rs
+++ b/src/client/twin.rs
@@ -92,6 +92,12 @@ pub trait Twin {
     ) -> Result<()>;
 
     fn set_option(&self, option_name: CString, value: *const std::ffi::c_void) -> Result<()>;
+
+    fn set_retry_policy(
+        &self,
+        policy: IOTHUB_CLIENT_RETRY_POLICY,
+        timeout_secs: usize,
+    ) -> Result<()>;
 }
 
 #[cfg(feature = "edge_client")]
@@ -301,6 +307,26 @@ impl Twin for ModuleTwin {
             Ok(())
         }
     }
+
+    fn set_retry_policy(
+        &self,
+        policy: IOTHUB_CLIENT_RETRY_POLICY,
+        timeout_secs: usize,
+    ) -> Result<()> {
+        unsafe {
+            if IOTHUB_CLIENT_RESULT_TAG_IOTHUB_CLIENT_OK
+                != IoTHubClient_SetRetryPolicy(
+                    self.handle.expect("no handle"),
+                    policy,
+                    timeout_secs,
+                )
+            {
+                anyhow::bail!("error while calling IoTHubClient_SetRetryPolicy()");
+            }
+
+            Ok(())
+        }
+    }
 }
 
 #[cfg(feature = "device_client")]
@@ -485,6 +511,26 @@ impl Twin for DeviceTwin {
                 )
             {
                 anyhow::bail!("error while calling IoTHubDeviceClient_SetOption()");
+            }
+
+            Ok(())
+        }
+    }
+
+    fn set_retry_policy(
+        &self,
+        policy: IOTHUB_CLIENT_RETRY_POLICY,
+        timeout_secs: usize,
+    ) -> Result<()> {
+        unsafe {
+            if IOTHUB_CLIENT_RESULT_TAG_IOTHUB_CLIENT_OK
+                != IoTHubDeviceClient_SetRetryPolicy(
+                    self.handle.expect("no handle"),
+                    policy,
+                    timeout_secs,
+                )
+            {
+                anyhow::bail!("error while calling IoTHubDeviceClient_SetRetryPolicy()");
             }
 
             Ok(())


### PR DESCRIPTION
1. removed trait objects since not needed anymore in client testcode
2. introduced builder pattern in order to keep number of function params small for better usage in client code
3. added API to set PnP modelID
4. added API to set retry policy
5. replaced anonymous tuples and triples by structs (`IncomingIotMessage` and `DirectMethod`) for better handling in client code