### PR TITLE
fix: improved error handling and output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["omnect@conplement.de>"]
 edition = "2021"
 name = "azure-iot-sdk"
 repository = "git@github.com:omnect/azure-iot-sdk.git"
-version = "0.13.2"
+version = "0.13.3"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -939,18 +939,6 @@ impl IotHubClient {
                 self.confirmation_set.borrow().len()
             );
         }
-        // spawn a task to handle the following results:
-        //   - succeeded
-        //   - failed
-        //   - timed out
-        self.confirmation_set.borrow_mut().spawn(async move {
-            match timeout(Duration::from_secs(Self::get_confirmation_timeout()), rx).await {
-                // if really needed we could pass around the json of property or D2C msg to get logged here as context
-                Ok(Ok(false)) => error!("confirmation failed"),
-                Err(_) => warn!("confirmation timed out"),
-                _ => debug!("confirmation successfully received"),
-            }
-        });
 
         /*
            We abort and join all "wait for pending confirmations" tasks

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -939,6 +939,18 @@ impl IotHubClient {
                 self.confirmation_set.borrow().len()
             );
         }
+        // spawn a task to handle the following results:
+        //   - succeeded
+        //   - failed
+        //   - timed out
+        self.confirmation_set.borrow_mut().spawn(async move {
+            match timeout(Duration::from_secs(Self::get_confirmation_timeout()), rx).await {
+                // if really needed we could pass around the json of property or D2C msg to get logged here as context
+                Ok(Ok(false)) => error!("confirmation failed"),
+                Err(_) => warn!("confirmation timed out"),
+                _ => debug!("confirmation successfully received"),
+            }
+        });
 
         /*
            We abort and join all "wait for pending confirmations" tasks


### PR DESCRIPTION
- more robustness regarding missing confirmations from c sdk:
  - wait up to 30s
  - log an error instead of panic
- improved error output of some logs