### PR TITLE
fix: handle unknown AuthenticationStatus::Unauthenticated status

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["omnect@conplement.de>"]
 edition = "2021"
 name = "azure-iot-sdk"
 repository = "git@github.com:omnect/azure-iot-sdk.git"
-version = "0.13.3"
+version = "0.13.4"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -939,18 +939,6 @@ impl IotHubClient {
                 self.confirmation_set.borrow().len()
             );
         }
-        // spawn a task to handle the following results:
-        //   - succeeded
-        //   - failed
-        //   - timed out
-        self.confirmation_set.borrow_mut().spawn(async move {
-            match timeout(Duration::from_secs(Self::get_confirmation_timeout()), rx).await {
-                // if really needed we could pass around the json of property or D2C msg to get logged here as context
-                Ok(Ok(false)) => error!("confirmation failed"),
-                Err(_) => warn!("confirmation timed out"),
-                _ => debug!("confirmation successfully received"),
-            }
-        });
 
         /*
            We abort and join all "wait for pending confirmations" tasks

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1299,7 +1299,7 @@ impl IotHubClient {
         let result = Box::from_raw(context as *mut oneshot::Sender<bool>);
 
         if result.send(status_code == 204).is_err() {
-            error!("c_reported_twin_callback: cannot send confirmation result since receiver already timed out and dropped ");
+            error!("c_reported_twin_callback: cannot send confirmation result {status_code} since receiver already timed out and dropped ");
         }
     }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -120,6 +120,8 @@ pub enum UnauthenticatedReason {
     NoNetwork,
     /// other communication error
     CommunicationError,
+    /// unknown
+    Unknown,
 }
 
 /// Authentication status as a result of establishing a connection
@@ -1173,7 +1175,10 @@ impl IotHubClient {
                     }
                     _ => {
                         error!("unknown unauthenticated reason");
-                        return;
+
+                        AuthenticationStatus::Unauthenticated(
+                            UnauthenticatedReason::Unknown,
+                        )
                     }
                 }
             }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -939,6 +939,18 @@ impl IotHubClient {
                 self.confirmation_set.borrow().len()
             );
         }
+        // spawn a task to handle the following results:
+        //   - succeeded
+        //   - failed
+        //   - timed out
+        self.confirmation_set.borrow_mut().spawn(async move {
+            match timeout(Duration::from_secs(Self::get_confirmation_timeout()), rx).await {
+                // if really needed we could pass around the json of property or D2C msg to get logged here as context
+                Ok(Ok(false)) => error!("confirmation failed"),
+                Err(_) => warn!("confirmation timed out"),
+                _ => debug!("confirmation successfully received"),
+            }
+        });
 
         /*
            We abort and join all "wait for pending confirmations" tasks


### PR DESCRIPTION
There are cases when azure-iot-sdk-c reports an connection state `unauthenticated` with no special reason, e.g. after changing network adapter options. In order to handle that situation an `unknown` reason is reported to the application.